### PR TITLE
Fixes danger dependency version

### DIFF
--- a/danger-gitlab.gemspec
+++ b/danger-gitlab.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |spec|
   spec.files         = %w(README.md LICENSE)
   spec.required_ruby_version = ">= 2.0.0"
 
-  spec.add_runtime_dependency  "danger", "> 4.0"
+  spec.add_runtime_dependency  "danger", ">= 4.0"
   spec.add_runtime_dependency "gitlab", "~> 3.7"
 end


### PR DESCRIPTION
Hi!
I'm new to `danger` and would like to set it up for our internal GitLab instance. So I started with guides on danger.systems.
Gemfile:
```
# frozen_string_literal: true
source "https://rubygems.org"

gem 'cocoapods', '~> 1.1'
gem 'fastlane', '~> 1.106'
gem 'sqlite3'
gem 'pry'
gem 'CFPropertyList'

gem 'danger'
gem 'danger-gitlab'
```

After running `bundle install` got this error:
```
Fetching gem metadata from https://rubygems.org/.........
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "danger":
  In Gemfile:
    danger

    danger-gitlab was resolved to 1.0.0, which depends on
      danger (> 4.0)

Could not find gem 'danger (> 4.0)', which is required by gem 'danger-gitlab', in any of the sources.
```

Making version rule less strict fixes the issue.