### PR TITLE
Gitlab version

### DIFF
--- a/danger-gitlab.gemspec
+++ b/danger-gitlab.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.0.0"
 
   spec.add_runtime_dependency  "danger", ">= 5.0"
-  spec.add_runtime_dependency "gitlab", "~> 4.0"
+  spec.add_runtime_dependency "gitlab", "~> 4.2.0"
 end

--- a/danger-gitlab.gemspec
+++ b/danger-gitlab.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "danger-gitlab"
-  spec.version       = "5.0.1"
+  spec.version       = "5.0.2"
   spec.authors       = ["Orta Therox", "Juanito Fatas"]
   spec.email         = ["orta.therox@gmail.com", "me@juanitofatas.com"]
   spec.license       = "MIT"


### PR DESCRIPTION
Use gitlab gem version not less than 4.2.0. Need for https://github.com/danger/danger/pull/861.