### PR TITLE
Bump danger version

### DIFF
--- a/danger-gitlab.gemspec
+++ b/danger-gitlab.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |spec|
   spec.files         = %w(README.md LICENSE)
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_runtime_dependency  "danger", "~> 8.0"
+  spec.add_runtime_dependency  "danger"
   spec.add_runtime_dependency "gitlab", "~> 4.2" ,">= 4.2.0"
 end

--- a/danger-gitlab.gemspec
+++ b/danger-gitlab.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "danger-gitlab"
-  spec.version       = "7.0.0"
+  spec.version       = "8.0.0"
   spec.authors       = ["Orta Therox", "Juanito Fatas"]
   spec.email         = ["orta.therox@gmail.com", "me@juanitofatas.com"]
   spec.license       = "MIT"
@@ -13,6 +13,6 @@ Gem::Specification.new do |spec|
   spec.files         = %w(README.md LICENSE)
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_runtime_dependency  "danger", "~> 6.0"
+  spec.add_runtime_dependency  "danger", "~> 8.0"
   spec.add_runtime_dependency "gitlab", "~> 4.2" ,">= 4.2.0"
 end


### PR DESCRIPTION
From 6.x to 8.x.
Also align danger-gitlab version to danger version

Fixes #8 