### PR TITLE
Drop support for Ruby < 3.1 and depend on gitlab ~> 5.0

### DIFF
--- a/danger-gitlab.gemspec
+++ b/danger-gitlab.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "danger-gitlab"
-  spec.version       = "8.0.0"
+  spec.version       = "9.0.0"
   spec.authors       = ["Orta Therox", "Juanito Fatas"]
   spec.email         = ["orta.therox@gmail.com", "me@juanitofatas.com"]
   spec.license       = "MIT"
@@ -11,8 +11,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/danger/danger"
 
   spec.files         = %w(README.md LICENSE)
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
-  spec.add_runtime_dependency  "danger"
-  spec.add_runtime_dependency "gitlab", "~> 4.2" ,">= 4.2.0"
+  spec.add_runtime_dependency "danger"
+  spec.add_runtime_dependency "gitlab", "~> 5.0"
 end


### PR DESCRIPTION
The `gitlab` gem recently released version `5.0.0` which dropped support for Ruby < 3.1: https://github.com/NARKOZ/gitlab/releases/tag/v5.0.0.

This updates the gemspec file to work with the new version.

This bumps the gem's version to 9.0.0.