### PR TITLE
Bump `gitlab` gem to version 6.0

### DIFF
--- a/danger-gitlab.gemspec
+++ b/danger-gitlab.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "danger-gitlab"
-  spec.version       = "9.0.0"
+  spec.version       = "10.0.0"
   spec.authors       = ["Orta Therox", "Juanito Fatas"]
   spec.email         = ["orta.therox@gmail.com", "me@juanitofatas.com"]
   spec.license       = "MIT"

--- a/danger-gitlab.gemspec
+++ b/danger-gitlab.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_runtime_dependency "danger"
-  spec.add_runtime_dependency "gitlab", "~> 5.0"
+  spec.add_runtime_dependency "gitlab", "~> 6.0"
 end


### PR DESCRIPTION
### About

This PR introduces a bump to the `gitlab` gem which [recently](https://github.com/NARKOZ/gitlab/releases/tag/v6.0.0) had a new version bump to `6.0.0`. I've also included a major version update seeing as:

- The `gitlab` gem version bump is a major version
- This seems to be pattern for relatively important changes to this gem after looking at some blames.

Our infrastructure relies on this `gitlab` to be running `6.0.0`, so I've made changes and locally built `danger-gitlab-gem` to make sure this those changes work. Please let me know if there are however any extra steps that need to be taken in order to test this change.

Thank you.
